### PR TITLE
chore: update workflows and build scripts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24.11
+          node-version-file: ".nvmrc"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Set up Node.js
+      - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 24.11

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -2,7 +2,7 @@ name: Pre-commit auto-update
 
 on:
   schedule:
-    - cron: 0 7 * * 1  # runs every Monday at 07:00 AM UTC (08:00 AM CET / 09:00 AM CEST)
+    - cron: "0 7 * * 1"  # runs every Monday at 07:00 AM UTC (08:00 AM CET / 09:00 AM CEST)
   workflow_dispatch:
 
 permissions:
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.14
+          python-version: '3.14'
 
       - name: Install pre-commit
         run: pip install pre-commit

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## 📚 Documentation
 
-See the documentation at [docs/index.md](./docs/index.md).
+Learn more at [docs/index.md](./docs/index.md).
 
 ## 🧱 Tech Stack
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -174,6 +174,9 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -193,6 +196,9 @@
       "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -214,6 +220,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -233,6 +242,9 @@
       "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -254,6 +266,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -273,6 +288,9 @@
       "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -4,10 +4,9 @@
   "description": "My portfolio website",
   "homepage": "https://mnau23.github.io",
   "scripts": {
-    "build:css": "sass scss:dist/css",
-    "deploy": "gh-pages -d dist",
+    "build:css": "sass scss:dist/css --no-source-map",
     "serve": "serve dist",
-    "watch": "sass --watch scss:dist/css"
+    "watch": "sass scss:dist/css --watch"
   },
   "author": "mnau23",
   "license": "MIT",


### PR DESCRIPTION
Changes:
- use node version file and cache in `deploy.yml` workflow
- fix `build:css` script for avoiding the `.map` file in the `gh-pages` branch
